### PR TITLE
Fixed Content component wrapping issue (ticket # USWDS-267)

### DIFF
--- a/lib/css/styles.css
+++ b/lib/css/styles.css
@@ -170,3 +170,5 @@ pre {
 
 .usa-label {
   margin-top: 0 !important; }
+
+.usa-prose>p{max-width:100%}


### PR DESCRIPTION
Overwritten max-width from 68ex to 100% for .usa-prose>p. This bug is currently filed under ticket # USWDS-267.