### PR TITLE
FIO-10483: update circle remove to circle xmark

### DIFF
--- a/src/templates/uswds/datagrid/form.ejs
+++ b/src/templates/uswds/datagrid/form.ejs
@@ -43,7 +43,7 @@
         {% if (!ctx.builder && ctx.hasRemoveButtons) { %}
         <td>
           <button type="button" class="usa-button usa-button--secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}">
-            <i class="{{ctx.iconClass('remove-circle')}}"></i>
+            <i class="{{ctx.iconClass('circle-xmark')}}"></i>
           </button>
         </td>
         {% } %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10483

## Description

**What changed?**

Updated circle-remove to circle-xmark

**Why have you chosen this solution?**

circle-remove is a old class name from fontawesome 3.x and fontawsome is on 7.x now and uses circle-xmark instead

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

https://github.com/formio/bootstrap/pull/137

## How has this PR been tested?

manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above