### PR TITLE
Add alt text to logo img

### DIFF
--- a/src/templates/uswds/webform/form.ejs
+++ b/src/templates/uswds/webform/form.ejs
@@ -1,6 +1,6 @@
 <div class="{{ctx.classes}}" ref="webform" novalidate>{{ctx.children}}</div>
 <!-- Please reach out to Form.io to purchase an Enterprise License. -->
 {% if (!Formio || !Formio.license) { %}
-    <small style="float:right;">powered by &nbsp;<a target="_blank" href="https://form.io"><img style="height:20px;float:right;" src="https://help.form.io/assets/formio-logo.png" /></a></small>
+    <small style="float:right;">powered by &nbsp;<a target="_blank" href="https://form.io"><img style="height:20px;float:right;" src="https://help.form.io/assets/formio-logo.png" alt="Form.io logo"/></a></small>
 {% } %}
 <!-- -------------------------------------------------------------- -->


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

Hi! I am working on a project that uses USWDS form.io library: https://dsacms.github.io/codejson-generator/. I am currently working on improving my website's accessibility score and would like to contribute upstream to solve this for all projects.

At the bottom of every form is a one-liner that credits Form.io. Currently, the logo is not being displayed at the moment and does not have an associated `alt` tag with it, so I am receiving the following lighthouse error:
<img width="115" height="43" alt="Screenshot 2025-09-04 at 1 01 46 PM" src="https://github.com/user-attachments/assets/f4c9c656-0c8c-4477-9cda-c4c570ed82c7" />
<img width="764" height="336" alt="Screenshot 2025-09-04 at 1 04 22 PM" src="https://github.com/user-attachments/assets/ee1fba6a-dbf8-409b-83e8-e5dc5253acf4" />

This PR adds an `alt` tag describing the `img`.

**Why have you chosen this solution?**

Since the image is currently not rendering, the lighthouse error points out that the element should have an alt tag associated with it.

It would be great to get the image to display but at the moment, this solution suffices!

## Breaking Changes / Backwards Compatibility

- None

## Dependencies

- None

## How has this PR been tested?

- I ran `npm test` and all tests pass. 

If there are any other testing processes I need to run, please let me know! This is my first time contributing so not sure what the contributing processes are.

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [X] Any dependent changes have corresponding PRs that are listed above