### PR TITLE
Add aria-label to remove row button in datagrid component

### DIFF
--- a/src/templates/uswds/datagrid/form.ejs
+++ b/src/templates/uswds/datagrid/form.ejs
@@ -42,7 +42,7 @@
       {% if (ctx.hasExtraColumn) { %}
         {% if (!ctx.builder && ctx.hasRemoveButtons) { %}
         <td>
-          <button type="button" class="usa-button usa-button--secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}">
+          <button type="button" class="usa-button usa-button--secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}" aria-label="Remove row from data grid">
             <i class="{{ctx.iconClass('remove-circle')}}"></i>
           </button>
         </td>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

Hi! I am working on a project that uses USWDS form.io library: https://dsacms.github.io/codejson-generator/. I am currently working on improving my website's accessibility score and would like to contribute upstream to solve this for all projects.

Currently, the remove row button in the data-grid component does not have an accessible name, so I am receiving the following lighthouse error:
<img width="738" height="323" alt="Screenshot 2025-09-04 at 1 20 58 PM" src="https://github.com/user-attachments/assets/278357df-336f-4d92-9445-b792c7b128db" />

This PR adds an `aria-label` tag describing the remove row`button` for screen readers.

**Why have you chosen this solution?**

The remove row button in the data-grid component does not have an accessible name, so adding an `aria-label` to this button.

## Breaking Changes / Backwards Compatibility

- None

## Dependencies

- None

## How has this PR been tested?

- I ran `npm test` and all tests pass. 

If there are any other testing processes I need to run, please let me know! This is my first time contributing so not sure what the contributing processes are.

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [X] Any dependent changes have corresponding PRs that are listed above